### PR TITLE
Add RLP encoder and ECDSA signing helpers

### DIFF
--- a/nRFBox_Eth/src/rlp.cpp
+++ b/nRFBox_Eth/src/rlp.cpp
@@ -1,0 +1,70 @@
+/* ____________________________
+   This software is licensed under the MIT License:
+   https://github.com/cifertech/nrfbox
+   ________________________________________ */
+
+#include "rlp.h"
+#include <string.h>
+
+static size_t rlp_encode_length(size_t len, uint8_t offset, uint8_t *out) {
+    if (len < 56) {
+        out[0] = offset + len;
+        return 1;
+    }
+    size_t l = len;
+    uint8_t tmp[8];
+    int idx = 0;
+    while (l > 0) {
+        tmp[idx++] = l & 0xFF;
+        l >>= 8;
+    }
+    out[0] = offset + 55 + idx;
+    for (int i = 0; i < idx; ++i) {
+        out[1 + i] = tmp[idx - 1 - i];
+    }
+    return 1 + idx;
+}
+
+size_t rlp_encode_bytes(const uint8_t *data, size_t len, uint8_t *out) {
+    if (len == 1 && data[0] < 0x80) {
+        out[0] = data[0];
+        return 1;
+    }
+    size_t p = rlp_encode_length(len, 0x80, out);
+    memcpy(out + p, data, len);
+    return p + len;
+}
+
+size_t rlp_encode_uint64(uint64_t value, uint8_t *out) {
+    if (value == 0) {
+        out[0] = 0x80;
+        return 1;
+    }
+    uint8_t buf[8];
+    int len = 0;
+    while (value > 0) {
+        buf[7 - len] = value & 0xFF;
+        value >>= 8;
+        len++;
+    }
+    return rlp_encode_bytes(buf + 8 - len, len, out);
+}
+
+size_t rlp_encode_bigint(const uint8_t *data, size_t len, uint8_t *out) {
+    while (len > 0 && *data == 0) {
+        ++data;
+        --len;
+    }
+    if (len == 0) {
+        out[0] = 0x80;
+        return 1;
+    }
+    return rlp_encode_bytes(data, len, out);
+}
+
+size_t rlp_encode_list(const uint8_t *data, size_t len, uint8_t *out) {
+    size_t p = rlp_encode_length(len, 0xC0, out);
+    memcpy(out + p, data, len);
+    return p + len;
+}
+

--- a/nRFBox_Eth/src/rlp.h
+++ b/nRFBox_Eth/src/rlp.h
@@ -1,0 +1,16 @@
+/* ____________________________
+   This software is licensed under the MIT License:
+   https://github.com/cifertech/nrfbox
+   ________________________________________ */
+
+#ifndef RLP_H
+#define RLP_H
+
+#include <Arduino.h>
+
+size_t rlp_encode_uint64(uint64_t value, uint8_t *out);
+size_t rlp_encode_bytes(const uint8_t *data, size_t len, uint8_t *out);
+size_t rlp_encode_bigint(const uint8_t *data, size_t len, uint8_t *out);
+size_t rlp_encode_list(const uint8_t *data, size_t len, uint8_t *out);
+
+#endif // RLP_H

--- a/nRFBox_Eth/src/utils_crypto.cpp
+++ b/nRFBox_Eth/src/utils_crypto.cpp
@@ -24,3 +24,7 @@ void utils_crypto_keccak(const uint8_t *data, size_t len, uint8_t *hash) {
     keccak_final(hash, &ctx);
 }
 
+bool utils_crypto_sign(const uint8_t *hash32, const uint8_t *privateKey, uint8_t *sig64) {
+    return uECC_sign(privateKey, hash32, 32, sig64, uECC_secp256k1()) == 1;
+}
+

--- a/nRFBox_Eth/src/utils_crypto.h
+++ b/nRFBox_Eth/src/utils_crypto.h
@@ -14,5 +14,6 @@ void utils_crypto_setup();
 void utils_crypto_loop();
 void utils_crypto_public_key(const uint8_t *privateKey, uint8_t *publicKey);
 void utils_crypto_keccak(const uint8_t *data, size_t len, uint8_t *hash);
+bool utils_crypto_sign(const uint8_t *hash32, const uint8_t *privateKey, uint8_t *sig64);
 
 #endif // UTILS_CRYPTO_H

--- a/nRFBox_Eth/src/wallet.cpp
+++ b/nRFBox_Eth/src/wallet.cpp
@@ -4,6 +4,9 @@
    ________________________________________ */
 
 #include "wallet.h"
+#include "utils_crypto.h"
+#include "rlp.h"
+#include <string.h>
 
 void wallet_setup() {
     // TODO: initialize wallet
@@ -11,5 +14,44 @@ void wallet_setup() {
 
 void wallet_loop() {
     // TODO: implement wallet runtime logic
+}
+
+size_t wallet_signTransaction(const EthTransaction *tx, const uint8_t *privateKey, uint8_t *out) {
+    uint8_t buf[256];
+    size_t p = 0;
+    p += rlp_encode_uint64(tx->nonce, buf + p);
+    p += rlp_encode_uint64(tx->gasPrice, buf + p);
+    p += rlp_encode_uint64(tx->gasLimit, buf + p);
+    p += rlp_encode_bytes(tx->to, sizeof(tx->to), buf + p);
+    p += rlp_encode_uint64(tx->value, buf + p);
+    p += rlp_encode_bytes(tx->data, tx->dataLen, buf + p);
+    p += rlp_encode_uint64(tx->chainId, buf + p);
+    p += rlp_encode_uint64(0, buf + p);
+    p += rlp_encode_uint64(0, buf + p);
+
+    uint8_t tmp[300];
+    size_t listLen = rlp_encode_list(buf, p, tmp);
+
+    uint8_t hash[32];
+    utils_crypto_keccak(tmp, listLen, hash);
+
+    uint8_t sig[64];
+    if (!utils_crypto_sign(hash, privateKey, sig)) {
+        return 0;
+    }
+
+    p = 0;
+    p += rlp_encode_uint64(tx->nonce, buf + p);
+    p += rlp_encode_uint64(tx->gasPrice, buf + p);
+    p += rlp_encode_uint64(tx->gasLimit, buf + p);
+    p += rlp_encode_bytes(tx->to, sizeof(tx->to), buf + p);
+    p += rlp_encode_uint64(tx->value, buf + p);
+    p += rlp_encode_bytes(tx->data, tx->dataLen, buf + p);
+    uint64_t v = (uint64_t)tx->chainId * 2 + 35;
+    p += rlp_encode_uint64(v, buf + p);
+    p += rlp_encode_bigint(sig, 32, buf + p);
+    p += rlp_encode_bigint(sig + 32, 32, buf + p);
+
+    return rlp_encode_list(buf, p, out);
 }
 

--- a/nRFBox_Eth/src/wallet.h
+++ b/nRFBox_Eth/src/wallet.h
@@ -6,9 +6,21 @@
 #ifndef WALLET_H
 #define WALLET_H
 
-// Placeholder header for wallet module
+// Simple Ethereum wallet utilities
+
+typedef struct {
+    uint32_t nonce;
+    uint64_t gasPrice;
+    uint64_t gasLimit;
+    uint8_t to[20];
+    uint64_t value;
+    const uint8_t *data;
+    size_t dataLen;
+    uint32_t chainId;
+} EthTransaction;
 
 void wallet_setup();
 void wallet_loop();
+size_t wallet_signTransaction(const EthTransaction *tx, const uint8_t *privateKey, uint8_t *out);
 
 #endif // WALLET_H


### PR DESCRIPTION
## Summary
- add a tiny RLP encoder
- expose ECDSA `utils_crypto_sign()` helper
- implement `wallet_signTransaction()` that RLP encodes and signs

## Testing
- `platformio run` *(fails: PlatformIO can't install dependencies without network)*

------
https://chatgpt.com/codex/tasks/task_e_683df826e714832898d75034893cd179