### PR TITLE
Add basic OLED ETH display

### DIFF
--- a/nRFBox_Eth/src/display_eth.cpp
+++ b/nRFBox_Eth/src/display_eth.cpp
@@ -3,13 +3,65 @@
    https://github.com/cifertech/nrfbox
    ________________________________________ */
 
+
 #include "display_eth.h"
 
+// The main U8g2 object lives in main.cpp or another module.
+// Declare it here so the display helpers can use it.
+extern U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2;
+
 void display_eth_setup() {
-    // TODO: initialize display_eth
+    u8g2.begin();
+    u8g2.clearBuffer();
+    u8g2.setFont(u8g2_font_6x10_tf);
+    u8g2.drawStr(0, 10, "ETH Firmware");
+    u8g2.sendBuffer();
+}
+
+void display_drawAddress(const char *address) {
+    u8g2.clearBuffer();
+    u8g2.setFont(u8g2_font_6x10_tf);
+    u8g2.drawStr(0, 10, "Address:");
+    u8g2.setFont(u8g2_font_5x8_tf);
+    u8g2.drawStr(0, 25, address);
+    u8g2.sendBuffer();
+}
+
+void display_drawBalance(const char *balance) {
+    u8g2.clearBuffer();
+    u8g2.setFont(u8g2_font_6x10_tf);
+    u8g2.drawStr(0, 10, "Balance:");
+    u8g2.setFont(u8g2_font_6x12_tf);
+    u8g2.drawStr(0, 25, balance);
+    u8g2.sendBuffer();
+}
+
+void display_drawTxStatus(const char *status) {
+    u8g2.clearBuffer();
+    u8g2.setFont(u8g2_font_6x10_tf);
+    u8g2.drawStr(0, 10, "TX Status:");
+    u8g2.setFont(u8g2_font_6x12_tf);
+    u8g2.drawStr(0, 25, status);
+    u8g2.sendBuffer();
+}
+
+void display_drawSettings(bool neoPixelEnabled, uint8_t brightness) {
+    char buf[20];
+
+    u8g2.clearBuffer();
+    u8g2.setFont(u8g2_font_6x10_tf);
+    u8g2.drawStr(0, 10, "Settings");
+
+    u8g2.drawStr(0, 25, neoPixelEnabled ? "NeoPixel: On" : "NeoPixel: Off");
+
+    snprintf(buf, sizeof(buf), "Bright: %u", brightness);
+    u8g2.drawStr(0, 40, buf);
+
+    u8g2.sendBuffer();
 }
 
 void display_eth_loop() {
-    // TODO: implement display_eth runtime logic
+    // This firmware is under heavy development.
+    // Nothing to update continuously yet.
 }
 

--- a/nRFBox_Eth/src/display_eth.h
+++ b/nRFBox_Eth/src/display_eth.h
@@ -6,9 +6,16 @@
 #ifndef DISPLAY_ETH_H
 #define DISPLAY_ETH_H
 
-// Placeholder header for display_eth module
+#include <U8g2lib.h>
+
+// Basic OLED UI helpers for the Ethereum firmware
 
 void display_eth_setup();
 void display_eth_loop();
+
+void display_drawAddress(const char *address);
+void display_drawBalance(const char *balance);
+void display_drawTxStatus(const char *status);
+void display_drawSettings(bool neoPixelEnabled, uint8_t brightness);
 
 #endif // DISPLAY_ETH_H


### PR DESCRIPTION
## Summary
- add display helpers for address, balance, TX status and settings screens

## Testing
- `platformio run -e esp32dev` *(fails: PlatformIO needs network)*

------
https://chatgpt.com/codex/tasks/task_e_683df990d434832897a64e801cbfb82d